### PR TITLE
Support openqasm3_parser v 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oq3_lexer"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c1e1b6015360f999d2f44310df253bbe4bb757f8e4212976f6ccac32594829"
+checksum = "e8f6303be37523a10661992d1b2bad0dedb3a3d48d1456fb9063bc24c3c163de"
 dependencies = [
  "unicode-properties",
  "unicode-xid",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "oq3_parser"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000b3f22a52bb46f7c7a27c3aad0602a337bf21c6e51ff18c4c932ec50e62d61"
+checksum = "339e60e3f8dea874d1ccb88bbad83c8cc5b0605496e39a49b9f63cc1084a8492"
 dependencies = [
  "drop_bomb",
  "oq3_lexer",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "oq3_semantics"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7615d2eac8cca6e75ae7e647ebadf2fee5372f300453a9c789b67f5fa1d91495"
+checksum = "9820764c68bdc7b8824c1fca5e6a1fe5207494618dc1ef7b92cdd50257d17350"
 dependencies = [
  "boolenum",
  "hashbrown 0.14.3",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "oq3_source_file"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffda2ed90e88699e2178f2495141a97cc84f6c9fd0769ca43acb8cceb79022b"
+checksum = "df3c32d150b88b003e7d5153ce89a7266c10c9c409a1bdc6b7cf56f8cb0b9b63"
 dependencies = [
  "ariadne",
  "oq3_syntax",
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "oq3_syntax"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db850066b59357bc2355afd6644aa7d64d6f7e22a90ea59e5a4e5560b410d25e"
+checksum = "562bf567f609ee30b592fad90882f1a60dd6ff6b38cba72a09958c82ac65d3ac"
 dependencies = [
  "cov-mark",
  "either",

--- a/crates/qasm3/Cargo.toml
+++ b/crates/qasm3/Cargo.toml
@@ -18,4 +18,4 @@ extension-module = ["pyo3/extension-module"]
 pyo3.workspace = true
 indexmap.version = "2.1.0"
 hashbrown.version = "0.14.0"
-oq3_semantics = "0.0.5"
+oq3_semantics = "0.0.6"

--- a/crates/qasm3/src/build.rs
+++ b/crates/qasm3/src/build.rs
@@ -131,9 +131,6 @@ impl BuilderState {
         ast_symbols: &SymbolTable,
         call: &asg::GateCallExpr,
     ) -> PyResult<()> {
-        // if call.modifier().is_some() {
-        //     return Err(QASM3ImporterError::new_err("gate modifiers not handled"));
-        // }
         let gate_id = call
             .name()
             .as_ref()


### PR DESCRIPTION
GateCall was replaced by GateCallExpr and was made an Stmt::ExprStmt.

This PR does not support gate modifiers, which *are* supported by openqasm3_parser v 0.0.6.